### PR TITLE
Typo in index.mdx

### DIFF
--- a/pages/docs/react/index.mdx
+++ b/pages/docs/react/index.mdx
@@ -27,4 +27,4 @@ Run the following to install the package:
 npm install @statickit/react
 ```
 
-This library assumes that React is already installed in your environment. Our components are build with [React Hooks](https://reactjs.org/docs/hooks-intro.html), so **you must be on version 16.8.0 or higher**.
+This library assumes that React is already installed in your environment. Our components are built with [React Hooks](https://reactjs.org/docs/hooks-intro.html), so **you must be on version 16.8.0 or higher**.


### PR DESCRIPTION
I think this should be "built with".