### PR TITLE
Fix broken anchor on pricing page

### DIFF
--- a/pages/pricing.tsx
+++ b/pages/pricing.tsx
@@ -163,7 +163,7 @@ function PricingPage() {
 
               <dt>
                 <h2
-                  id="#sandbox-limits"
+                  id="sandbox-limits"
                   className="pb-3 text-xl font-semibold tracking-snug"
                 >
                   What are the sandbox limits?


### PR DESCRIPTION
The sandbox limits anchor currently doesn't work due to a malformed ID.