### PR TITLE
Fix useForm hook code in Mailchimp form example

### DIFF
--- a/pages/guides/mailchimp-react.mdx
+++ b/pages/guides/mailchimp-react.mdx
@@ -77,10 +77,10 @@ You'll be prompted with instructions on how to save your Mailchimp API key and a
 Wire up your form component using the `useForm` hook:
 
 ```jsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm, ValidationError } from '@statickit/react';
 
-function OptInForm(props) {
+function OptInForm() {
   const [state, handleSubmit] = useForm("optInForm");
 
   if (state.succeeded) {
@@ -108,6 +108,8 @@ function OptInForm(props) {
     </form>
   );
 }
+
+export default OptInForm;
 ```
 
 [Learn more about StaticKit forms &rarr;](/docs/forms)


### PR DESCRIPTION
While setting up a StaticKit form on a new project, I noticed that the useForm hook code sample had some small issues.

This PR:
- Removes the unused `props` argument
- Removes the unused `useState` import
- Adds the missing default export