### PR TITLE
Fix useForm hook code in ConvertKit form example

### DIFF
--- a/pages/guides/convertkit-react.mdx
+++ b/pages/guides/convertkit-react.mdx
@@ -78,10 +78,10 @@ You'll be prompted with instructions on how to save your ConvertKit API secret.
 Wire up your form component using the `useForm` hook:
 
 ```jsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm, ValidationError } from '@statickit/react';
 
-function OptInForm(props) {
+function OptInForm() {
   const [state, handleSubmit] = useForm("optInForm");
 
   if (state.succeeded) {
@@ -109,6 +109,8 @@ function OptInForm(props) {
     </form>
   );
 }
+
+export default OptInForm;
 ```
 
 [Learn more about StaticKit forms &rarr;](/docs/forms)


### PR DESCRIPTION
While setting up a StaticKit form on a new project, I noticed that the useForm hook code sample had some small issues.

This PR:
- Removes the unused `props` argument
- Removes the unused `useState` import
- Adds the missing default export