### PR TITLE
Fix next anchor link on docs/functions page

### DIFF
--- a/pages/docs/functions/index.mdx
+++ b/pages/docs/functions/index.mdx
@@ -14,7 +14,7 @@ export default withDocs({
     label: 'Forms'
   },
   next: {
-    path: '/docs/guides',
+    path: '/guides',
     label: 'Guides'
   }
 });


### PR DESCRIPTION
Path should be '/guides' not '/docs/guides'